### PR TITLE
Osgood refactor

### DIFF
--- a/check_display_darwin.go
+++ b/check_display_darwin.go
@@ -1,0 +1,12 @@
+//go:build darwin
+// +build darwin
+
+package webbrowser
+
+func DisplayValid() (err error) {
+	// Check SSH env vars.
+	if os.Getenv("SSH_CLIENT") != "" || os.Getenv("SSH_TTY") != "" {
+		return errors.New("you are running a shell session")
+	}
+	return nil
+}

--- a/check_display_linux.go
+++ b/check_display_linux.go
@@ -1,0 +1,18 @@
+//go:build linux
+// +build linux
+
+package webbrowser
+
+import (
+	"errors"
+	"os"
+)
+
+func DisplayValid() (err error) {
+	// No display, no need to open a browser. Lynx users **MAY** have
+	// something to say about this.
+	if os.Getenv("DISPLAY") == "" {
+		return errors.New("no screen found")
+	}
+	return nil
+}

--- a/check_display_others.go
+++ b/check_display_others.go
@@ -1,0 +1,8 @@
+//go:build !linux && !darwin
+// +build !linux,!darwin
+
+package webbrowser
+
+func DisplayValid() (err error) {
+	return nil
+}

--- a/command_darwin.go
+++ b/command_darwin.go
@@ -1,0 +1,7 @@
+//go:build darwin
+// +build darwin
+
+package webbrowser
+
+// command to execute when running on a mac.
+var openCommand *browserCommand = &browserCommand{"open", nil}

--- a/command_invalid.go
+++ b/command_invalid.go
@@ -1,0 +1,6 @@
+//go:build !windows && !darwin && !android && !freebsd && !linux && !netbsd && !openbsd
+// +build !windows,!darwin,!android,!freebsd,!linux,!netbsd,!openbsd
+
+package webbrowser
+
+var openCommand *browserCommand = nil

--- a/command_others.go
+++ b/command_others.go
@@ -1,0 +1,7 @@
+//go:build android || freebsd || linux || netbsd || openbsd
+// +build android freebsd linux netbsd openbsd
+
+package webbrowser
+
+// command to run when on android, freebsd, linux, netbsd, or openbsd
+var openCommand *browserCommand = &browserCommand{"xdg-open", nil}

--- a/command_windows.go
+++ b/command_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+// +build windows
+
+package webbrowser
+
+// command to execute when on a windows
+var openCommand *browserCommand = &browserCommand{"cmd", []string{"/c", "start"}}

--- a/custom_errors.go
+++ b/custom_errors.go
@@ -1,0 +1,6 @@
+package webbrowser
+
+import "errors"
+
+var ErrCantOpenBrowser error = errors.New("webbrowser: can't open browser")
+var ErrNoCandidates error = errors.New("webbrowser: no browser candidate found for your OS")

--- a/functions.go
+++ b/functions.go
@@ -1,0 +1,58 @@
+package webbrowser
+
+import (
+	"fmt"
+	"net/url"
+	"runtime"
+	"strings"
+)
+
+// Open tries to open a URL in your default browser ensuring you have a display
+// set up and not running this from SSH. NOTE: This may cause your program to
+// hang until the browser process is closed in some OSes, see
+// https://github.com/toqueteos/webbrowser/issues/4.
+func Open(s string) (err error) {
+	if openCommand == nil {
+		return ErrNoCandidates
+	}
+
+	// Try to determine if there's a display available (only linux) and we
+	// aren't on a terminal (all but windows).
+	err = DisplayValid()
+	if err != nil {
+		return fmt.Errorf("webbrowser: tried to open %q, but %s", s, err.Error())
+	}
+
+	// Try all candidates
+	for _, candidate := range Candidates {
+		err := candidate.Open(s)
+		if err == nil {
+			return nil
+		}
+	}
+
+	return ErrCantOpenBrowser
+}
+
+func ensureScheme(u *url.URL) {
+	for _, s := range winSchemes {
+		if u.Scheme == s {
+			return
+		}
+	}
+	u.Scheme = "http"
+}
+
+func ensureValidURL(u *url.URL) string {
+	// Enforce a scheme (windows requires scheme to be set to work properly).
+	ensureScheme(u)
+	s := u.String()
+
+	// Escape characters not allowed by cmd/bash
+	switch runtime.GOOS {
+	case "windows":
+		s = strings.Replace(s, "&", `^&`, -1)
+	}
+
+	return s
+}

--- a/globals.go
+++ b/globals.go
@@ -1,0 +1,8 @@
+package webbrowser
+
+// Candidates contains a list of registered `Browser`s that will be tried with Open.
+var Candidates []Browser
+
+// string array containing the three options for
+// a link's scheme.
+var winSchemes [3]string = [3]string{"https", "http", "file"}

--- a/init.go
+++ b/init.go
@@ -1,4 +1,5 @@
 package webbrowser
 
 func init() {
+	Candidates = append(Candidates, openCommand)
 }

--- a/init.go
+++ b/init.go
@@ -1,0 +1,4 @@
+package webbrowser
+
+func init() {
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,0 +1,12 @@
+package webbrowser
+
+import "os/exec"
+
+type Browser interface {
+	// Command returns a ready to be used Cmd that will open an URL.
+	Command(string) (*exec.Cmd, error)
+	// Open tries to open a URL in your default browser. NOTE: This may cause
+	// your program to hang until the browser process is closed in some OSes,
+	// see https://github.com/toqueteos/webbrowser/issues/4.
+	Open(string) error
+}

--- a/structs.go
+++ b/structs.go
@@ -1,0 +1,10 @@
+package webbrowser
+
+// structure defining a command that will open up
+// the webbrowser.
+type browserCommand struct {
+	// command to execute.
+	cmd string
+	// command arguments passed into exec.Command.
+	args []string
+}

--- a/webbrowser.go
+++ b/webbrowser.go
@@ -3,93 +3,9 @@
 package webbrowser
 
 import (
-	"errors"
-	"fmt"
 	"net/url"
-	"os"
 	"os/exec"
-	"runtime"
-	"strings"
 )
-
-var (
-	ErrCantOpenBrowser = errors.New("webbrowser: can't open browser")
-	ErrNoCandidates    = errors.New("webbrowser: no browser candidate found for your OS")
-)
-
-// Candidates contains a list of registered `Browser`s that will be tried with Open.
-var Candidates []Browser
-
-type Browser interface {
-	// Command returns a ready to be used Cmd that will open an URL.
-	Command(string) (*exec.Cmd, error)
-	// Open tries to open a URL in your default browser. NOTE: This may cause
-	// your program to hang until the browser process is closed in some OSes,
-	// see https://github.com/toqueteos/webbrowser/issues/4.
-	Open(string) error
-}
-
-// Open tries to open a URL in your default browser ensuring you have a display
-// set up and not running this from SSH. NOTE: This may cause your program to
-// hang until the browser process is closed in some OSes, see
-// https://github.com/toqueteos/webbrowser/issues/4.
-func Open(s string) (err error) {
-	if len(Candidates) == 0 {
-		return ErrNoCandidates
-	}
-
-	// Try to determine if there's a display available (only linux) and we
-	// aren't on a terminal (all but windows).
-	switch runtime.GOOS {
-	case "linux":
-		// No display, no need to open a browser. Lynx users **MAY** have
-		// something to say about this.
-		if os.Getenv("DISPLAY") == "" {
-			return fmt.Errorf("webbrowser: tried to open %q, no screen found", s)
-		}
-		fallthrough
-	case "darwin":
-		// Check SSH env vars.
-		if os.Getenv("SSH_CLIENT") != "" || os.Getenv("SSH_TTY") != "" {
-			return fmt.Errorf("webbrowser: tried to open %q, but you are running a shell session", s)
-		}
-	}
-
-	// Try all candidates
-	for _, candidate := range Candidates {
-		err := candidate.Open(s)
-		if err == nil {
-			return nil
-		}
-	}
-
-	return ErrCantOpenBrowser
-}
-
-func init() {
-	// Register the default Browser for current OS, if it exists.
-	if os, ok := osCommand[runtime.GOOS]; ok {
-		Candidates = append(Candidates, browserCommand{os.cmd, os.args})
-	}
-}
-
-var (
-	osCommand = map[string]*browserCommand{
-		"android": &browserCommand{"xdg-open", nil},
-		"darwin":  &browserCommand{"open", nil},
-		"freebsd": &browserCommand{"xdg-open", nil},
-		"linux":   &browserCommand{"xdg-open", nil},
-		"netbsd":  &browserCommand{"xdg-open", nil},
-		"openbsd": &browserCommand{"xdg-open", nil}, // It may be open instead
-		"windows": &browserCommand{"cmd", []string{"/c", "start"}},
-	}
-	winSchemes = [3]string{"https", "http", "file"}
-)
-
-type browserCommand struct {
-	cmd  string
-	args []string
-}
 
 func (b browserCommand) Command(s string) (*exec.Cmd, error) {
 	u, err := url.Parse(s)
@@ -111,27 +27,4 @@ func (b browserCommand) Open(s string) error {
 	}
 
 	return cmd.Run()
-}
-
-func ensureScheme(u *url.URL) {
-	for _, s := range winSchemes {
-		if u.Scheme == s {
-			return
-		}
-	}
-	u.Scheme = "http"
-}
-
-func ensureValidURL(u *url.URL) string {
-	// Enforce a scheme (windows requires scheme to be set to work properly).
-	ensureScheme(u)
-	s := u.String()
-
-	// Escape characters not allowed by cmd/bash
-	switch runtime.GOOS {
-	case "windows":
-		s = strings.Replace(s, "&", `^&`, -1)
-	}
-
-	return s
 }


### PR DESCRIPTION
## Refactor

This PR contains refactor of the code structure, not its functionality. The purpose of this refactor is to make the individual files smaller, and make the overall repository more conducive to logic/code additions. By separating the OS specific code in its own file, the cross-platform functionality is easier to expand on without having to manually check the OS.

The main changes are:

- Split  up OS-specific functions/logic into their own files.
- Moved non browserOption functions out of `webbrowser.go`.
- Moved generic (non-browserOption) functions to a `functions.go` file.
- Moved global variables to a `globals.go` file.
- Added build directives at the top of OS-specific files.
- Moved custom errors to `custom_errors.go`.